### PR TITLE
Added two tutorials to CGC

### DIFF
--- a/Tutorials/CGC/Task automation with tumor-normal matched samples.ipynb
+++ b/Tutorials/CGC/Task automation with tumor-normal matched samples.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How can I make, validate, and run many tasks with tumor-normal bam file matching?\n",
+    "\n",
+    "In this tutorial, you will learn how to match bam files that belong to the same primary tumor and solid tissue normal samples that belong to the same TCGA case ID and run tasks with the tumor-normal matched files. To learn how to import these files using the Datasets API, please use the **Tumor Tissue Normal Matched TCGA.ipynb** tutorial.\n",
+    "\n",
+    "## Objective\n",
+    "This tutorial introduces you to performing an analysis where you match the tumor-normal files for same patient using the API with the sevenbridges-python bindings library.\n",
+    "\n",
+    "## Procedure\n",
+    "We are going to assume that you already contain a project with the appropriate bam files.\n",
+    "\n",
+    " 1. Find an existing project.\n",
+    " 2. Copy app from public apps to the project.\n",
+    " 3. Print an app's input ports.\n",
+    " 4. Copy reference file from public files.\n",
+    " 5. Create tasks with tumor-normal matched bam files.\n",
+    "\n",
+    "## Prerequisites\n",
+    "You need your authentication token and the API needs to know about it. See Setup_API_environment.ipynb for details.\n",
+    "You have imported the tumor-normal TCGA bam files within the platform to an existing project. The **Tumor Tissue Normal Matched TCGA.ipynb** tutorial provides a method to perform this input.\n",
+    "\n",
+    "## Imports\n",
+    "We import the Api class from the official sevenbridges-python bindings below.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import sevenbridges as sbg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize the object\n",
+    "The Api object needs to know your auth_token and the correct path. Here we assume you are using the .sbgrc file in your home directory. For other options see Setup_API_environment.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# [USER INPUT] Specify platform {cgc, sbg}\n",
+    "prof = 'cgc'\n",
+    "\n",
+    "\n",
+    "config_file = sbg.Config(profile=prof)\n",
+    "api = sbg.Api(config=config_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1) Find an existing project\n",
+    "\n",
+    "Find the project within your project space using the name of the project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "my_project_name = 'matched tumor-normal samples'\n",
+    "my_project = [p for p in api.projects.query(limit=100).all() \\\n",
+    "              if p.name == my_project_name]\n",
+    "\n",
+    "# Double-check that target project exists\n",
+    "if not my_project:\n",
+    "    print('Target project (%s) not found, check spelling' % my_project_name)\n",
+    "    raise KeyboardInterrupt\n",
+    "else:\n",
+    "    my_project = my_project[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2) Find an app within the public tools and copy it to the project\n",
+    "\n",
+    "We will find the VarScan2 Workflow from BAM app within the public tools and copy it to the project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "app_name = \"VarScan2 Workflow from BAM\"\n",
+    "\n",
+    "public_app = [a for a in api.apps.query(visibility='public', limit=100).all() \\\n",
+    "                 if a.name == app_name]\n",
+    "\n",
+    "# Double-check that source app exists among the public apps\n",
+    "if not public_app:\n",
+    "    print('Target app (%s) not found, check spelling' % app_name)\n",
+    "    raise KeyboardInterrupt\n",
+    "else:\n",
+    "    public_app = public_app[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "App already exists in second project. Using this app in stead.\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_apps = api.apps.query(project = my_project.id, limit=100)\n",
+    "\n",
+    "duplicate_app = [a for a in my_apps.all() if a.name == public_app.name]\n",
+    "\n",
+    "if duplicate_app:\n",
+    "    print('App already exists in second project. Using this app instead.')\n",
+    "    new_app = duplicate_app[0]\n",
+    "else:\n",
+    "    print('App (%s) does not exist in Project (%s); copying now' % \\\n",
+    "          (app_name, my_project.name))\n",
+    "    \n",
+    "    new_app = public_app.copy(project = my_project.id)\n",
+    "        \n",
+    "    # re-list apps in target project to verify the copy worked\n",
+    "    my_app_names = [a.name for a in \\\n",
+    "                    api.apps.query(project = my_project.id, limit=100).all()]\n",
+    "    \n",
+    "    if app_name in my_app_names:\n",
+    "        print('Sucessfully copied one app!')\n",
+    "    else:\n",
+    "        print('Something went wrong...')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3) Getting details of the inputs for the app.\n",
+    "\n",
+    "In this step, we will identify the input ports for the Varscan2 workflow so that we can get the appropriate ports set with input files for each task."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This app has 3 input ports\n",
+      "Input port 1 with input id #input_fasta_file\n",
+      "Input port 2 with input id #Tumor_BAM\n",
+      "Input port 3 with input id #Normal_BAM\n"
+     ]
+    }
+   ],
+   "source": [
+    "idx = 1\n",
+    "print(\"This app has {} input ports\".format(len(new_app.raw[\"inputs\"])))\n",
+    "for eachInput in  new_app.raw[\"inputs\"]:\n",
+    "    print(\"Input port {} with input id {}\".format(idx, eachInput[\"id\"]))\n",
+    "    idx += 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4) Copying the reference fasta file for the tasks.\n",
+    "\n",
+    "In this step, we will copy the ucsc.hg19.fasta file from the public reference files to the project. We then use this copied file as the reference file (input_fasta_file input port) for each task."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "ref_file_name = 'ucsc.hg19.fasta'\n",
+    "source_project_id = 'admin/sbg-public-data'  \n",
+    "source_files = list(api.files.query(limit = 100, project = source_project_id).all())\n",
+    "reqd_input_file = [currFile for currFile in source_files if currFile.name == ref_file_name]\n",
+    "\n",
+    "if not reqd_input_file:\n",
+    "    print('File does not exist. Cannot copy.')\n",
+    "else:\n",
+    "    reqd_input_file = reqd_input_file[0]\n",
+    "    copied_file = reqd_input_file.copy(project=my_project.id,  name = reqd_input_file.name)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5) Create tasks for each tumor-tissue normal matched file.\n",
+    "\n",
+    "In this step, we will identify all the bam files that Primary tumor samples and Solid Tissue Normal samples that belong to the same patient (case ID in TCGA). Then we use these matched bam files as inputs to the Tumor_BAM and Normal_BAM input ports for VarScan2 and start multiple VarScan2 tasks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "all_files = list(api.files.query(project=my_project.id, limit=100).all())\n",
+    "tumor_bam_files = [curr_file for curr_file in all_files if curr_file.name.endswith(\".bam\") and curr_file.metadata[\"sample_type\"] == \"Primary Tumor\"]\n",
+    "normal_bam_files = [curr_file for curr_file in all_files if curr_file.name.endswith(\".bam\") and curr_file.metadata[\"sample_type\"] == \"Solid Tissue Normal\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "inputs = {}\n",
+    "inputs[\"input_fasta_file\"] = copied_file\n",
+    "all_tasks = []\n",
+    "for curr_tumor_file in tumor_bam_files:\n",
+    "    matched_normal_files = [curr_file for curr_file in normal_bam_files if curr_file.metadata[\"case_id\"] == curr_tumor_file.metadata[\"case_id\"]]\n",
+    "    for curr_matched_normal_file in matched_normal_files:\n",
+    "        inputs[\"Tumor_BAM\"] = curr_tumor_file\n",
+    "        inputs[\"Normal_BAM\"] = curr_matched_normal_file\n",
+    "        task_name = \"VarScan2 with \" + curr_tumor_file.name + \" and \" + curr_matched_normal_file.name\n",
+    "        my_task = api.tasks.create(name=task_name, project=my_project.id, \\\n",
+    "                                    app=new_app.id, inputs=inputs, run=False)\n",
+    "        #my_task.run()\n",
+    "        all_tasks.append(my_task)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/Tutorials/CGC/Task automation with tumor-normal matched samples.ipynb
+++ b/Tutorials/CGC/Task automation with tumor-normal matched samples.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -124,19 +124,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "App already exists in second project. Using this app in stead.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "my_apps = api.apps.query(project = my_project.id, limit=100)\n",
     "\n",
@@ -172,22 +164,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This app has 3 input ports\n",
-      "Input port 1 with input id #input_fasta_file\n",
-      "Input port 2 with input id #Tumor_BAM\n",
-      "Input port 3 with input id #Normal_BAM\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "idx = 1\n",
     "print(\"This app has {} input ports\".format(len(new_app.raw[\"inputs\"])))\n",
@@ -207,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -237,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -250,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },

--- a/Tutorials/CGC/Tumor Tissue Normal Matched TCGA.ipynb
+++ b/Tutorials/CGC/Tumor Tissue Normal Matched TCGA.ipynb
@@ -1,0 +1,516 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programmatically Access TCGA Data using the Seven Bridges Cancer Genomics Cloud via the Datasets API\n",
+    "\n",
+    "TCGA is one of the world’s largest cancer genomics data collections, including more than eleven thousand patients, representing 33 cancers, and over half a million total files. Seven Bridges has created a unified metadata ontology from the diverse cancer studies, made this data available, and provided compute infrastructure to facilitate customized analyses on the Cancer Genomics Cloud (the CGC). The CGC provides powerful methods to query and reproducibly analyze TCGA data - alone or in conjunction with your own data.\n",
+    "We continue to develop new methods of interacting with data on the CGC, however, we also appreciate that sometimes it is useful to be able to analyze data locally, or in an AWS environment that you have configured yourself. While the CGC has undergone thorough testing and is certified as a FISMA-moderate system, if you wish to analyze data in alternative locations, you must take the appropriate steps to ensure your computing environment is secure and compliant with current best practices. If you plan to download large numbers of files for local analysis, we recommend using the download utilities available from the Genomic Data Commons which have been specifically optimized for this purpose.\n",
+    "Below, we provide a tutorial showing how to find and access TCGA data using the Datasets API. Alternatively, you can try to query TCGA data using a SPARQL query.\n",
+    "\n",
+    "\n",
+    "## Goal of this Tutorial\n",
+    "During this tutorial, you will learn how to use the Datasets API to get the gene expression files for tumor-normal tissue matched Breast Cancer datasets.  In order to do this, we need to first identify the primary tumor and normal tissue samples from BRCA for which RNA-seq experiments have been performed. We then identify the tumor-tissue normal matched RNA-seq datasets by identifying which cases or patients had both experiments performed on them. After identifying these patients, we can then get the gene expression files for these tumor-normal matched datasets.\n",
+    "\n",
+    "## Prerequisites\n",
+    "Before you begin this tutorial, you should:\n",
+    " 1. ** Set up your CGC account. ** If you haven't already done so, navigate to https://cgc.sbgenomics.com/ and follow these directions to register for the CGC. This tutorial uses Open Data, which is available to all CGC users. The same approach can be used by approved researchers to access Controlled Data. Learn more about TCGA data access here.3 \n",
+    " 2. ** Install the Seven Bridges' API Python library. ** This tutorial uses the library sevenbridges-python. Learn how to install it before continuing.\n",
+    " 3. ** Obtain your authentication token. ** You'll use your authentication token to encode your user credentials when interacting with the CGC programmatically. Learn how to access your authentication token. It is important to store your authentication token in a safe place as it can be used to access your account. The time and location your token was last used is shown on the developer dashboard. If for any reason you believe your token has been compromised, you can regenerate it at any time.\n",
+    " \n",
+    "## Query using the Datasets API\n",
+    "The Datasets API is an API designed around the TCGA data structure and focused on search functionality. You can use the Datasets API to browse TCGA using API requests written in JSON. Queries made using the Datasets API return entities and are particularly suitable for browsing TCGA data.\n",
+    "We'll write a Python script to issue our query into TCGA using the Datasets API. Since the Datasets API is not included in our Python library, sevenbridges-python, we will use two Python modules, json and requests, to interact with it instead. We'll use these modules to write a wrapper around the API request."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from requests import request"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below, we define a simple function to send and receive JSONs from the API using the correctly formatted HTTP calls. The necessary imports are handled above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def api_call(path, method='GET', query=None, data=None, token=None):\n",
+    "     \n",
+    "    base_url = 'https://cgc-datasets-api.sbgenomics.com/datasets/tcga/v0/'\n",
+    "     \n",
+    "    data = json.dumps(data) if isinstance(data, dict) \\\n",
+    "    or isinstance(data,list) else None\n",
+    "               \n",
+    "    headers = {\n",
+    "        'X-SBG-Auth-Token': token,\n",
+    "        'Accept': 'application/json',\n",
+    "        'Content-type': 'application/json',\n",
+    "    }\n",
+    "     \n",
+    "    response = request(method, base_url + path, params=query, \\\n",
+    "                       data=data, headers=headers)\n",
+    "    response_dict = response.json() if \\\n",
+    "    response.json() else {}\n",
+    " \n",
+    "    if response.status_code / 100 != 2:\n",
+    "        print(response_dict['message'])\n",
+    "        print('Error Code: %i.' % (response_dict['code']))\n",
+    "        print(response_dict['more_info'])\n",
+    "        raise Exception('Server responded with status code %s.' \\\n",
+    "                        % response.status_code)\n",
+    "    return response_dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then, provide your authentication token, as shown below. Examples of proper coding of your auth_token are available for sevenbridges-python bindings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "auth_token = 'Enter your Authentication token here'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we can define a query in JSON for finding all primary tumor samples that are Breast Invasive Carcinoma and those that have RNA-seq experiments performed. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tumor_samples_query = {\n",
+    "    \"entity\": \"samples\",\n",
+    "    \"hasSampleType\": \"Primary Tumor\",\n",
+    "    \"hasCase\": {\n",
+    "        \"hasDiseaseType\" : \"Breast Invasive Carcinoma\",\n",
+    "        \"hasGender\" : \"FEMALE\",\n",
+    "        \"hasVitalStatus\" : \"Alive\"\n",
+    "        },\n",
+    "    \"hasFile\": {\n",
+    "        \"hasExperimentalStrategy\": \"RNA-Seq\",\n",
+    "         \"hasDataType\" : \"Gene expression\"\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "total = api_call(method='POST', path ='query/total', \\\n",
+    "                 token=auth_token, data=tumor_samples_query)\n",
+    "print(\"There are {} samples matching the query\".format(total['total']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below, we define a simple function to get all matches to the query in the API using the correctly formatted HTTP calls. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
+    "def getAllMatches(auth_token, query_body):\n",
+    "    numberFiles = api_call(method=\"POST\", path=\"query/total\", \\\n",
+    "                                       token=auth_token, data=query_body)[\"total\"]\n",
+    "    numCalls = int(math.ceil(numberFiles/100.0))\n",
+    "    matches = []\n",
+    "    entity = query_body[\"entity\"]\n",
+    "    for i in range(0, numCalls):\n",
+    "        query_body[\"offset\"] = str(i * 100)\n",
+    "        currSet = api_call(method=\"POST\", path=\"query\" \\\n",
+    "            , token=auth_token, data=query_body)[\"_embedded\"][entity]\n",
+    "        for currMatch in currSet:\n",
+    "            matches.append(currMatch)\n",
+    "\n",
+    "    return matches"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using these functions, we can now get all the samples that match the required queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "tumor_samples = getAllMatches(auth_token, tumor_samples_query)\n",
+    "tumor_sample_ids = [curr_sample[\"id\"] for curr_sample in tumor_samples]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we can define a query in JSON for getting all normal tissue samples that are Breast Invasive Carcinoma and those that have RNA-seq experiments performed. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tissue_normal_samples_query = {\n",
+    "    \"entity\": \"samples\",\n",
+    "    \"hasSampleType\": \"Solid Tissue Normal\",\n",
+    "    \"hasCase\": {\n",
+    "        \"hasDiseaseType\" : \"Breast Invasive Carcinoma\",\n",
+    "        \"hasGender\" : \"FEMALE\",\n",
+    "        \"hasVitalStatus\" : \"Alive\"\n",
+    "        },\n",
+    "    \"hasFile\": {\n",
+    "        \"hasExperimentalStrategy\": \"RNA-Seq\",\n",
+    "        \"hasDataType\" : \"Gene expression\"\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "tissue_normal_samples = getAllMatches(auth_token, tissue_normal_samples_query)\n",
+    "tissue_normal_sample_ids = [curr_sample[\"id\"] for curr_sample in tissue_normal_samples]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "total = api_call(method='POST', path ='query/total', \\\n",
+    "                 token=auth_token, data=tissue_normal_samples_query)\n",
+    "print(\"There are {} samples matching the query\".format(total['total']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we are ready to identify the corresponding cases (patients) that have both tumor/normal matched RNA-seq experiments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tumor_cases_query = {\n",
+    "    \"entity\": \"cases\",\n",
+    "    \"hasSample\": tumor_sample_ids\n",
+    "}\n",
+    "tumor_cases = getAllMatches(auth_token, tumor_cases_query)\n",
+    "tumor_case_ids = [curr_case[\"id\"] for curr_case in tumor_cases]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "tissue_normal_cases_query = {\n",
+    "    \"entity\": \"cases\",\n",
+    "    \"hasSample\": tissue_normal_sample_ids\n",
+    "}\n",
+    "tissue_normal_cases = getAllMatches(auth_token, tissue_normal_cases_query)\n",
+    "tissue_normal_case_ids = [curr_case[\"id\"] for curr_case in tissue_normal_cases]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "tumor_match_case_ids = list(set(tumor_case_ids) & set(tissue_normal_case_ids))\n",
+    "print(\"There are {} cases that have both primary tumor and solid tissue normal samples with RNA-seq experiments\".format(len(tumor_match_case_ids)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we know the case IDs, we can use them to get the appropriate files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "tumor_match_files_query = {\n",
+    "    \"entity\": \"files\",\n",
+    "    \"hasExperimentalStrategy\": \"RNA-Seq\",\n",
+    "    \"hasDataType\" : \"Gene expression\",\n",
+    "    \"hasSample\": {\n",
+    "        \"hasSampleType\" : \"Primary Tumor\"\n",
+    "    },\n",
+    "    \"hasCase\": tumor_match_case_ids\n",
+    "}\n",
+    "tumor_match_files = getAllMatches(auth_token, tumor_match_files_query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tissue_normal_match_files_query = {\n",
+    "    \"entity\": \"files\",\n",
+    "    \"hasExperimentalStrategy\": \"RNA-Seq\",\n",
+    "    \"hasDataType\" : \"Gene expression\",\n",
+    "    \"hasSample\": {\n",
+    "        \"hasSampleType\" : \"Solid Tissue Normal\"\n",
+    "    },\n",
+    "    \"hasCase\": tumor_match_case_ids\n",
+    "}\n",
+    "tissue_normal_match_files = getAllMatches(auth_token, tissue_normal_match_files_query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"There are {} files corresponding to Gene Expression for Tumor samples in tumor-normal matched cases for BRCA\".format(len(tumor_match_files)))\n",
+    "print(\"There are {} files corresponding to Gene Expression for Solid tissue normal samples in tumor-normal matched cases for BRCA\".format(len(tissue_normal_match_files)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Initialize the sevenbridges-python library\n",
+    "We've now installed sevenbridges-python and stored our credentials in a config file. Let's import the api class from the official sevenbridges-python bindings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import sevenbridges as sbg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's initialize the api object so the API knows our credentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# [USER INPUT] specify platform {cgc, sbg}\n",
+    "prof = 'cgc'\n",
+    "\n",
+    "\n",
+    "config_file = sbg.Config(profile=prof)\n",
+    "api = sbg.Api(config=config_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a new project"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# [USER INPUT] Set project name here:\n",
+    "new_project_name = 'Matched Tumor-Control Samples'                          \n",
+    "      \n",
+    "    \n",
+    "# What are my funding sources?\n",
+    "billing_groups = api.billing_groups.query()  \n",
+    "\n",
+    "# Pick the first group (arbitrary)\n",
+    "print((billing_groups[0].name + \\\n",
+    "       ' will be charged for computation and storage (if applicable) for your new project'))\n",
+    "\n",
+    "# Set up the information for your new project\n",
+    "new_project = {\n",
+    "        'billing_group': billing_groups[0].id,\n",
+    "        'description': \"\"\"A project created by the API recipe (projects_makeNew.ipynb).\n",
+    "                      This also supports **markdown**\n",
+    "                      _Pretty cool_, right?\n",
+    "                   \"\"\",\n",
+    "        'name': new_project_name\n",
+    "}\n",
+    "\n",
+    "# check if this project already exists. LIST all projects and check for name match\n",
+    "my_project = [p for p in api.projects.query(limit=100).all() \\\n",
+    "              if p.name == new_project_name]      \n",
+    "              \n",
+    "if my_project:    # exploit fact that empty list is False, {list, tuple, etc} is True\n",
+    "    print('A project with the name (%s) already exists, please choose a unique name' \\\n",
+    "          % new_project_name)\n",
+    "    raise KeyboardInterrupt\n",
+    "else:\n",
+    "    # CREATE the new project\n",
+    "    my_project = api.projects.create(name = new_project['name'], \\\n",
+    "                                     billing_group = new_project['billing_group'], \\\n",
+    "                                     description = new_project['description'])\n",
+    "    \n",
+    "    # (re)list all projects, and get your new project\n",
+    "    my_project = [p for p in api.projects.query(limit=100).all() \\\n",
+    "              if p.name == new_project_name][0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copy the files based on file IDs that are transferrable across the Datasets and platform APIs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def copyToProject(api, my_project, finalFiles):\n",
+    "    my_files = api.files.query(limit = 100, project = my_project.id).all()\n",
+    "    # pop out the file names\n",
+    "    my_file_names = [f.name for f in my_files]\n",
+    "    newFiles = []\n",
+    "    for currFile in finalFiles:\n",
+    "        if currFile[\"label\"] in my_file_names:\n",
+    "            print('file already exists in second project, please try another file')\n",
+    "        else:\n",
+    "            fileObject = api.files.get(id = currFile['id'])\n",
+    "            #print fileObject.name, fileObject.id\n",
+    "            \n",
+    "            my_new_file = fileObject.copy(project = my_project.id, name = fileObject.name)\n",
+    "            newFiles.append(my_new_file)\n",
+    "    print \"Files Imported!\"\n",
+    "\n",
+    "copyToProject(api, my_project, tumor_match_files)\n",
+    "copyToProject(api, my_project, tissue_normal_match_files)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Two new tutorials added to CGC:
- Using the datasets API to find tumor-normal matched samples for RNA-seq datasets from a BRCA and import these files to a project using the CGC API.
- Using the CGC API to identify tumor-normal matches samples for the same patient and run tasks with these tumor-normal matched samples (one per pair).